### PR TITLE
DOC: clarify usage of assume_centered parameter in EmpiricalCovariance

### DIFF
--- a/doc/modules/covariance.rst
+++ b/doc/modules/covariance.rst
@@ -34,11 +34,11 @@ The empirical covariance matrix of a sample can be computed using the
 :func:`empirical_covariance` function of the package, or by fitting an
 :class:`EmpiricalCovariance` object to the data sample with the
 :meth:`EmpiricalCovariance.fit` method. Be careful that results depend
-on whether the data are centered, so one may want to use the
-``assume_centered`` parameter accurately. More precisely, if
-``assume_centered=False``, then the test set is supposed to have the
-same mean vector as the training set. If not, both should be centered
-by the user, and ``assume_centered=True`` should be used.
+on whether the data are centered, so one should use the ``assume_centered``
+parameter accordingly. More precisely, if ``assume_centered=True``, then
+the data set’s mean vector should be zero. Otherwise, the user should
+center the data before fitting or set ``assume_centered=False``.
+
 
 .. rubric:: Examples
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.

Clarified the description of the `assume_centered` parameter in the `EmpiricalCovariance` documentation. The previous explanation was slightly misleading and suggested centering data even when `assume_centered=False`, which was confusing.

Updated the docstring to clearly state:
- If `assume_centered=True`, the data should be zero-centered.
- Otherwise, the user can either center the data or rely on `assume_centered=False`.

#### Any other comments?

This is my first contribution to scikit-learn! Happy to receive feedback and learn more.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
